### PR TITLE
fix: make poethepoet a dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ urllib3 = [
 	{ version = ">=1.26", python = ">=3.10,<4" }
 ]
 requests-oauthlib = ">=1.2.0"
-poethepoet = ">=0.16.4"
 
 [tool.poetry.dev-dependencies]
 pyperclip = ">=1.7"
@@ -48,6 +47,7 @@ cffi = [
 	{ version = ">=1.15.0", markers = "sys_platform == 'darwin'" }
 ]
 pytest-rerunfailures = ">=10"
+poethepoet = ">=0.16.4"
 
 [tool.poetry.plugins] # Optional super table
 


### PR DESCRIPTION
I just got poethepoet in my dependency graph when upgrading to version 1.1.2.

<img width="628" alt="Screen Shot 2022-10-28 at 12 53 38" src="https://user-images.githubusercontent.com/435885/198571086-09c3a1ff-c5dd-4b4b-a47d-f9b28f44c2ca.png">

I'm also using this as a task runner in some projects but you probably want to have this as a dev dependency to not clobber the dependency graphs for users.

This PR makes it a dev dependency to fix the issue.