### PR TITLE
Add session parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,47 @@ Implementation of pyfilesystem2 file system using OneDrive
 
 # Usage
 
+`fs.onedrivefs` can create a [`requests_oauthlib.OAuth2Session`](https://requests-oauthlib.readthedocs.io/en/latest/oauth2_workflow.html#) for you. This way the `OAuth2Session` is going to refresh the tokens for you.
+
 ``` python
 onedriveFS = OneDriveFS(
   clientId=<your client id>,
   clientSecret=<your client secret>,
   token=<token JSON saved by oauth2lib>,
   SaveToken=<function which saves a new token string after refresh>)
+
+# onedriveFS is now a standard pyfilesystem2 file system
+```
+
+You can handle the tokens outside of the library by passing a [`requests.Session`](https://requests.readthedocs.io/en/latest/user/advanced/#session-objects).
+Here is an example of a custom session using [MSAL Python](https://learn.microsoft.com/en-us/entra/msal/python/)
+
+``` python
+class MSALSession(OAuth2Session):
+  def __init__(self, client: msal.ClientApplication):
+    super().__init__()
+    self.client = client
+
+  def request(self, *args, **kwargs):
+    account = self.client.get_accounts()[0]
+    self.token = self.client.acquire_token_silent_with_error(
+      scopes=["Files.ReadWrite"], account=account
+    )
+
+    return super().request(*args, **kwargs)
+
+client = msal.ConfidentialClientApplication(
+  client_id=<your client id>,
+  client_credential=<your client secret>,
+  authority=f"https://login.microsoftonline.com/<your tenant>",
+  token_cache=<your token cache>,
+)
+
+# Authentication flow to populate the token cache
+# YOUR AUTHENTICATION FLOW
+
+session = MSALSession(client=client)
+onedriveFS = OneDriveFS(session=session)
 
 # onedriveFS is now a standard pyfilesystem2 file system
 ```


### PR DESCRIPTION
Hello,

thank you for creating this library!

I have added a session parameter. The new parameter can be used to pass a [`requests.Session`](https://requests.readthedocs.io/en/latest/user/advanced/#session-objects)

I made these changes, because I would like to handle the authentication and the refresh of the tokens with [MSAL Python](https://learn.microsoft.com/en-us/entra/msal/python/)
The updated README includes the following example.

```python
class MSALSession(OAuth2Session):
  def __init__(self, client: msal.ClientApplication):
    super().__init__()
    self.client = client

  def request(self, *args, **kwargs):
    account = self.client.get_accounts()[0]
    self.token = self.client.acquire_token_silent_with_error(
      scopes=["Files.ReadWrite"], account=account
    )

    return super().request(*args, **kwargs)

client = msal.ConfidentialClientApplication(
  client_id=<your client id>,
  client_credential=<your client secret>,
  authority=f"https://login.microsoftonline.com/<your tenant>",
  token_cache=<your token cache>,
)

# Authentication flow to populate the token cache
# YOUR AUTHENTICATION FLOW

session = MSALSession(client=client)
onedriveFS = OneDriveFS(session=session)
```

This PR should resolve: #55